### PR TITLE
fix: add support for pulling configurations from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,8 @@
+apply plugin: 'com.android.library'
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 buildscript {
     repositories {
@@ -9,15 +14,13 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.library'
-
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }
@@ -33,4 +36,3 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 }
-  


### PR DESCRIPTION
During some RN upgrades. Our build failed.

```
* What went wrong:
Execution failed for task ':react-native-dns-lookup:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Android resource linking failed
     /Users/ghlegacy2/.gradle/caches/transforms-2/files-2.1/a4aa75ad6ccbe3ab81ae94031ca63766/appcompat-1.0.2/res/values-v26/values-v26.xml:5:5-8:13: AAPT: error: resource android:attr/colorError not found.
     /Users/ghlegacy2/.gradle/caches/transforms-2/files-2.1/a4aa75ad6ccbe3ab81ae94031ca63766/appcompat-1.0.2/res/values-v26/values-v26.xml:9:5-12:13: AAPT: error: resource android:attr/colorError not found.
```

The internet loves giving options that are large in scale (https://github.com/luggit/react-native-config/issues/299#issuecomment-431994106) and hinted at me changing all our subprojects with an override. That seems much larger than what I want to do. So I dug into it and this package is one of 3 that had some hard-coded configurations.

I patched to safely obtain a property from the root project (if it exists). Otherwise falling back to the existing. I did not change any of the values so the only true change is here is reaching out the root project as the fallbacks are the same as they were prior.
